### PR TITLE
chore: [#91] Update Renovate/release commit format

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "extends": [
     "config:base"
   ],
-  "commitMessagePrefix": "[chore]",
+  "commitMessagePrefix": "chore:",
   "automerge": true,
   "major": {
     "automerge": false


### PR DESCRIPTION
Change the format of the commit type to match the
Conventional Commits specification

Closes #91