### PR TITLE
fix(webpack): use static.directory for webpack-dev-server

### DIFF
--- a/webpack.development.js
+++ b/webpack.development.js
@@ -5,6 +5,8 @@ module.exports = merge(common, {
   mode: "development",
   devtool: "inline-source-map",
   devServer: {
-    contentBase: "./dist",
+    static: {
+      directory: "./dist",
+    },
   },
 });


### PR DESCRIPTION
Fixes #327  issue running `npm start`

![image](https://user-images.githubusercontent.com/563819/138894561-e80883de-eefe-491a-a9f5-1efd81af5f0c.png)
